### PR TITLE
NodeJSUtils.cmake: adding missing libraries to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,6 @@ if(J2V8_BUILD_ONLY_DEBUG_RELEASE)
 #}
 endif()
 
-# link against the static MS C++ runtime libraries
-if(MSVC)
-    link_static_crt()
-endif()
-
 # create the j2v8 library
 add_library(j2v8 SHARED ${src_files})
 

--- a/cmake/NodeJsUtils.cmake
+++ b/cmake/NodeJsUtils.cmake
@@ -18,14 +18,17 @@ function (get_njs_libs nodejs_dir config_name)
             ${njs_build_lib}/v8_base_1.lib
             ${njs_build_lib}/v8_base_2.lib
             ${njs_build_lib}/v8_base_3.lib
+            ${njs_build_lib}/v8_base_4.lib
+            ${njs_build_lib}/v8_base_5.lib
+			${njs_build_lib}/v8_base_6.lib
+			${njs_build_lib}/v8_base_7.lib
+			${njs_build_lib}/v8_base_8.lib
+			${njs_build_lib}/v8_base_9.lib
             ${njs_build_lib}/v8_libbase.lib
             ${njs_build_lib}/v8_libplatform.lib
             ${njs_build_lib}/v8_libsampler.lib
             ${njs_build_lib}/v8_nosnapshot.lib
             ${njs_build_lib}/v8_snapshot.lib
-
-            # nodejs/build/$Config
-            ${njs_build}/mksnapshot.lib
 
             # nodejs/$Config/lib
             ${njs_extra_lib}/cares.lib
@@ -40,9 +43,6 @@ function (get_njs_libs nodejs_dir config_name)
             ${njs_extra_lib}/node.lib
             ${njs_extra_lib}/openssl.lib
             ${njs_extra_lib}/zlib.lib
-
-            # nodejs/$Config
-            ${njs_extra}/cctest.lib
 
             # additional windows libs, required by Node.js
             Dbghelp

--- a/cmake/NodeJsUtils.cmake
+++ b/cmake/NodeJsUtils.cmake
@@ -20,10 +20,10 @@ function (get_njs_libs nodejs_dir config_name)
             ${njs_build_lib}/v8_base_3.lib
             ${njs_build_lib}/v8_base_4.lib
             ${njs_build_lib}/v8_base_5.lib
-			${njs_build_lib}/v8_base_6.lib
-			${njs_build_lib}/v8_base_7.lib
-			${njs_build_lib}/v8_base_8.lib
-			${njs_build_lib}/v8_base_9.lib
+            ${njs_build_lib}/v8_base_6.lib
+            ${njs_build_lib}/v8_base_7.lib
+            ${njs_build_lib}/v8_base_8.lib
+            ${njs_build_lib}/v8_base_9.lib
             ${njs_build_lib}/v8_libbase.lib
             ${njs_build_lib}/v8_libplatform.lib
             ${njs_build_lib}/v8_libsampler.lib


### PR DESCRIPTION
I am replacing my previous pull request with this one. It excludes some things that I have in a pull request over here (https://github.com/eclipsesource/J2V8/pull/259)